### PR TITLE
Fix progress bar output and exclude hanging entry temporarily

### DIFF
--- a/src/csd_optimade/ingest.py
+++ b/src/csd_optimade/ingest.py
@@ -118,7 +118,7 @@ def cli():
             ):
                 total_bad += bad_count
                 total += total_count
-                pbar.update(total)
+                pbar.update(total_count)
                 try:
                     pbar.set_postfix({"% bad": 100 * (total_bad / total)})
                 except ZeroDivisionError:


### PR DESCRIPTION
The entry `XIJZOB` is proving problematic, causing infinite hangs. For now I have skipped it, and will add a test later on.